### PR TITLE
Automatically produce all binaries for releases from GitHub Actions

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -55,8 +55,9 @@ jobs:
              bash check_7za.sh `pwd`/../bin/7za
              bash check_7zr.sh `pwd`/../bin/7zr
              cd ..
-             ./bin/7za a linux-p7zip.7z ./bin/* -y
-             ls linux-p7zip.7z
+             ls -l ./bin
+             ./bin/7za a linux-p7zip.7z ./bin/* -t7z -y
+             ./bin/7z a linux-p7zip.zip ./bin/* -tzip -y
 
   macos:
     name: macos-build
@@ -111,8 +112,9 @@ jobs:
              bash check_7za.sh `pwd`/../bin/7za
              bash check_7zr.sh `pwd`/../bin/7zr
              cd ..
-             ./bin/7za a macos-p7zip.7z ./bin/* -y
-             ls macos-p7zip.7z
+             ls -l ./bin
+             ./bin/7za a macos-p7zip.7z ./bin/* -t7z -y
+             ./bin/7z a macos-p7zip.zip ./bin/* -tzip -y
 
   ubuntu-cmake:
     name: ubuntu-cmake-build
@@ -169,8 +171,9 @@ jobs:
              bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
              cd ..
-             ./CPP/7zip/CMAKE/build/bin/7za a linux-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/* -y
-             ls linux-compatibly-p7zip.7z
+             ls -l ./CPP/7zip/CMAKE/build/bin/
+             ./CPP/7zip/CMAKE/build/bin/7za a linux-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* -t7z -y
+             ./CPP/7zip/CMAKE/build/bin/7z a linux-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* -tzip -y
 
   macos-cmake:
     name: macos-cmake-build
@@ -227,5 +230,6 @@ jobs:
              bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
              cd ..
-             ./CPP/7zip/CMAKE/build/bin/7za a macos-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/* -y
-             ls macos-compatibly-p7zip.7z
+             ls -l ./CPP/7zip/CMAKE/build/bin/
+             ./CPP/7zip/CMAKE/build/bin/7za a macos-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* -t7z -y
+             ./CPP/7zip/CMAKE/build/bin/7z a macos-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* -tzip -y

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -64,6 +64,7 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true
+
   macos:
     name: macos-build
     runs-on: macos-latest

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -172,6 +172,9 @@ jobs:
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
              cd ..
              ls -l ./CPP/7zip/CMAKE/build/bin/
+             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/CMakeFiles
+             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/Makefile
+             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/cmake_install.cmake
              ls -l ./CPP/7zip/CMAKE/build/bin/Codecs
              ./CPP/7zip/CMAKE/build/bin/7za a linux-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
              ./CPP/7zip/CMAKE/build/bin/7z_ a linux-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
@@ -232,6 +235,9 @@ jobs:
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
              cd ..
              ls -l ./CPP/7zip/CMAKE/build/bin/
+             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/CMakeFiles
+             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/Makefile
+             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/cmake_install.cmake
              ls -l ./CPP/7zip/CMAKE/build/bin/Codecs
              ./CPP/7zip/CMAKE/build/bin/7za a macos-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
              ./CPP/7zip/CMAKE/build/bin/7z_ a macos-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -7,7 +7,7 @@ jobs:
     name: ubuntu-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1    
+      - uses: actions/checkout@v2
       - name: build 7za & test
         run: |
              make 7za
@@ -31,7 +31,7 @@ jobs:
              echo "delete tmp file"
              rm -rf ./tr.7z ./CPP
              cd ..
-             
+
       - name: build 7z & test
         run: |
              make 7z
@@ -55,11 +55,20 @@ jobs:
              bash check_7za.sh `pwd`/../bin/7za
              bash check_7zr.sh `pwd`/../bin/7zr
              cd ..
+      - name: Upload the Linux binary artifacts
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: bin/*
+          asset_name: linux-p7zip
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
   macos:
     name: macos-build
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1    
+      - uses: actions/checkout@v2
       - name: build 7za & test
         run: |
              cp makefile.macosx_gcc_64bits makefile.machine
@@ -84,7 +93,7 @@ jobs:
              echo "delete tmp file"
              rm -rf ./tr.7z ./CPP
              cd ..
-             
+
       - name: build 7z & test
         run: |
              make 7z
@@ -108,12 +117,21 @@ jobs:
              bash check_7za.sh `pwd`/../bin/7za
              bash check_7zr.sh `pwd`/../bin/7zr
              cd ..
+      - name: Upload the macOS binary artifacts
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: bin/*
+          asset_name: macos-p7zip
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
 
   ubuntu-cmake:
     name: ubuntu-cmake-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: cmake build 7z_ & test
         run: |
              cd ./CPP/7zip/CMAKE/
@@ -132,7 +150,7 @@ jobs:
              diff -r ../../../Archive ./Archive
              echo "delte tmp file"
              rm -rf t_.7z Archive
-      
+
       - name: cmake build 7za & test
         run: |
              cd ./CPP/7zip/CMAKE/build/
@@ -144,7 +162,7 @@ jobs:
              diff -r ../../../Archive ./Archive
              echo "delete tmp file"
              rm -rf ta.7z Archive
-             
+
       - name: cmake build 7zr & test
         run: |
              cd ./CPP/7zip/CMAKE/build/
@@ -163,12 +181,21 @@ jobs:
              bash ./check.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7z_
              bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
+      - name: Upload the cmake Linux binary artifacts
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: bin/*
+          asset_name: linux-compatibly-p7zip
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
 
   macos-cmake:
     name: macos-cmake-build
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: cmake build 7z_ & test
         run: |
              cd ./CPP/7zip/CMAKE/
@@ -187,7 +214,7 @@ jobs:
              diff -r ../../../Archive ./Archive
              echo "delte tmp file"
              rm -rf t_.7z Archive
-      
+
       - name: cmake build 7za & test
         run: |
              cd ./CPP/7zip/CMAKE/build/
@@ -199,7 +226,7 @@ jobs:
              diff -r ../../../Archive ./Archive
              echo "delete tmp file"
              rm -rf ta.7z Archive
-             
+
       - name: cmake build 7zr & test
         run: |
              cd ./CPP/7zip/CMAKE/build/
@@ -218,3 +245,12 @@ jobs:
              bash ./check.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7z_
              bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
+      - name: Upload the cmake macOS binary artifacts
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: bin/*
+          asset_name: macos-compatibly-p7zip
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -172,8 +172,9 @@ jobs:
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
              cd ..
              ls -l ./CPP/7zip/CMAKE/build/bin/
-             ./CPP/7zip/CMAKE/build/bin/7za a linux-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* -t7z -y
-             ./CPP/7zip/CMAKE/build/bin/7z a linux-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* -tzip -y
+             ls -l ./CPP/7zip/CMAKE/build/bin/Codecs
+             ./CPP/7zip/CMAKE/build/bin/7za a linux-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
+             ./CPP/7zip/CMAKE/build/bin/7z_ a linux-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
 
   macos-cmake:
     name: macos-cmake-build
@@ -231,5 +232,6 @@ jobs:
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
              cd ..
              ls -l ./CPP/7zip/CMAKE/build/bin/
-             ./CPP/7zip/CMAKE/build/bin/7za a macos-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* -t7z -y
-             ./CPP/7zip/CMAKE/build/bin/7z a macos-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* -tzip -y
+             ls -l ./CPP/7zip/CMAKE/build/bin/Codecs
+             ./CPP/7zip/CMAKE/build/bin/7za a macos-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
+             ./CPP/7zip/CMAKE/build/bin/7z_ a macos-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -7,7 +7,7 @@ jobs:
     name: ubuntu-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       - name: build 7za & test
         run: |
              make 7za
@@ -55,15 +55,11 @@ jobs:
              bash check_7za.sh `pwd`/../bin/7za
              bash check_7zr.sh `pwd`/../bin/7zr
              cd ..
-             ls -l ./bin
-             ./bin/7za a linux-p7zip.7z ./bin/* -t7z -y
-             ./bin/7z a linux-p7zip.zip ./bin/* -tzip -y
-
   macos:
     name: macos-build
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       - name: build 7za & test
         run: |
              cp makefile.macosx_gcc_64bits makefile.machine
@@ -112,15 +108,12 @@ jobs:
              bash check_7za.sh `pwd`/../bin/7za
              bash check_7zr.sh `pwd`/../bin/7zr
              cd ..
-             ls -l ./bin
-             ./bin/7za a macos-p7zip.7z ./bin/* -t7z -y
-             ./bin/7z a macos-p7zip.zip ./bin/* -tzip -y
 
   ubuntu-cmake:
     name: ubuntu-cmake-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       - name: cmake build 7z_ & test
         run: |
              cd ./CPP/7zip/CMAKE/
@@ -170,20 +163,12 @@ jobs:
              bash ./check.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7z_
              bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
-             cd ..
-             ls -l ./CPP/7zip/CMAKE/build/bin/
-             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/CMakeFiles
-             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/Makefile
-             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/cmake_install.cmake
-             ls -l ./CPP/7zip/CMAKE/build/bin/Codecs
-             ./CPP/7zip/CMAKE/build/bin/7za a linux-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
-             ./CPP/7zip/CMAKE/build/bin/7z_ a linux-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
 
   macos-cmake:
     name: macos-cmake-build
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       - name: cmake build 7z_ & test
         run: |
              cd ./CPP/7zip/CMAKE/
@@ -233,11 +218,3 @@ jobs:
              bash ./check.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7z_
              bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
-             cd ..
-             ls -l ./CPP/7zip/CMAKE/build/bin/
-             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/CMakeFiles
-             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/Makefile
-             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/cmake_install.cmake
-             ls -l ./CPP/7zip/CMAKE/build/bin/Codecs
-             ./CPP/7zip/CMAKE/build/bin/7za a macos-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
-             ./CPP/7zip/CMAKE/build/bin/7z_ a macos-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,8 +192,8 @@ jobs:
              bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
              cd ..
-             ./CPP/7zip/CMAKE/build/bin/7za a linux-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* -t7z -y
-             ./CPP/7zip/CMAKE/build/bin/7z a linux-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* -tzip -y
+             ./CPP/7zip/CMAKE/build/bin/7za a linux-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
+             ./CPP/7zip/CMAKE/build/bin/7z_ a linux-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
       - name: Upload the cmake Linux binary artifacts
         uses: svenstaro/upload-release-action@v2
         with:
@@ -260,8 +260,8 @@ jobs:
              bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
              cd ..
-             ./CPP/7zip/CMAKE/build/bin/7za a macos-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* -t7z -y
-             ./CPP/7zip/CMAKE/build/bin/7z a macos-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* -tzip -y
+             ./CPP/7zip/CMAKE/build/bin/7za a macos-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
+             ./CPP/7zip/CMAKE/build/bin/7z_ a macos-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
       - name: Upload the cmake macOS binary artifacts
         uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,9 @@ jobs:
              bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
              cd ..
+             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/CMakeFiles
+             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/Makefile
+             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/cmake_install.cmake
              ./CPP/7zip/CMAKE/build/bin/7za a linux-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
              ./CPP/7zip/CMAKE/build/bin/7z_ a linux-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
       - name: Upload the cmake Linux binary artifacts
@@ -260,6 +263,9 @@ jobs:
              bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
              cd ..
+             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/CMakeFiles
+             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/Makefile
+             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/cmake_install.cmake
              ./CPP/7zip/CMAKE/build/bin/7za a macos-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
              ./CPP/7zip/CMAKE/build/bin/7z_ a macos-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
       - name: Upload the cmake macOS binary artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,13 @@
-name: BUILD
+name: Publish
 
-on: [push, pull_request]
+on:
+  push:
+    tags:
+      - '*'
 
 jobs:
   ubuntu:
-    name: ubuntu-build
+    name: ubuntu-binary
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -56,10 +59,18 @@ jobs:
              bash check_7zr.sh `pwd`/../bin/7zr
              cd ..
              ./bin/7za a linux-p7zip.7z ./bin/* -y
-             ls linux-p7zip.7z
+      - name: Upload the Linux binary artifacts
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: linux-p7zip.7z
+          asset_name: linux-p7zip
+          tag: ${{ github.ref }}
+          overwrite: true
+          body: "This is linux binary release using make"
 
   macos:
-    name: macos-build
+    name: macos-binary
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -112,10 +123,18 @@ jobs:
              bash check_7zr.sh `pwd`/../bin/7zr
              cd ..
              ./bin/7za a macos-p7zip.7z ./bin/* -y
-             ls macos-p7zip.7z
+      - name: Upload the macOS binary artifacts
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: macos-p7zip.7z
+          asset_name: macos-p7zip
+          tag: ${{ github.ref }}
+          overwrite: true
+          body: "This is macos binary release using make"
 
   ubuntu-cmake:
-    name: ubuntu-cmake-build
+    name: ubuntu-cmake-binary
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -170,10 +189,18 @@ jobs:
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
              cd ..
              ./CPP/7zip/CMAKE/build/bin/7za a linux-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/* -y
-             ls linux-compatibly-p7zip.7z
+      - name: Upload the cmake Linux binary artifacts
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: linux-compatibly-p7zip.7z
+          asset_name: linux-compatibly-p7zip
+          tag: ${{ github.ref }}
+          overwrite: true
+          body: "This is linux binary release using cmake"
 
   macos-cmake:
-    name: macos-cmake-build
+    name: macos-cmake-binary
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -228,4 +255,12 @@ jobs:
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
              cd ..
              ./CPP/7zip/CMAKE/build/bin/7za a macos-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/* -y
-             ls macos-compatibly-p7zip.7z
+      - name: Upload the cmake macOS binary artifacts
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: macos-compatibly-p7zip.7z
+          asset_name: macos-compatibly-p7zip
+          tag: ${{ github.ref }}
+          overwrite: true
+          body: "This is macos binary release using cmake"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
-name: Publish
+name: Release
 
 on:
-  push:
+  release:
     tags:
       - '*'
 
@@ -195,14 +195,14 @@ jobs:
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/CMakeFiles
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/Makefile
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/cmake_install.cmake
-             ./CPP/7zip/CMAKE/build/bin/7za a linux-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
-             ./CPP/7zip/CMAKE/build/bin/7z_ a linux-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
+             ./CPP/7zip/CMAKE/build/bin/7za a linux-cmake-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
+             ./CPP/7zip/CMAKE/build/bin/7z_ a linux-cmake-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
       - name: Upload the cmake Linux binary artifacts
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: linux-compatibly-p7zip.*
-          asset_name: linux-compatibly-p7zip
+          file: linux-cmake-p7zip.*
+          asset_name: linux-cmake-p7zip
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true
@@ -266,14 +266,14 @@ jobs:
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/CMakeFiles
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/Makefile
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/cmake_install.cmake
-             ./CPP/7zip/CMAKE/build/bin/7za a macos-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
-             ./CPP/7zip/CMAKE/build/bin/7z_ a macos-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
+             ./CPP/7zip/CMAKE/build/bin/7za a macos-cmake-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
+             ./CPP/7zip/CMAKE/build/bin/7z_ a macos-cmake-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
       - name: Upload the cmake macOS binary artifacts
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: macos-compatibly-p7zip.*
-          asset_name: macos-compatibly-p7zip
+          file: macos-cmake-p7zip.*
+          asset_name: macos-cmake-p7zip
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,15 +58,17 @@ jobs:
              bash check_7za.sh `pwd`/../bin/7za
              bash check_7zr.sh `pwd`/../bin/7zr
              cd ..
-             ./bin/7za a linux-p7zip.7z ./bin/* -y
+             ./bin/7za a linux-p7zip.7z ./bin/* -t7z -y
+             ./bin/7z a linux-p7zip.zip ./bin/* -tzip -y
       - name: Upload the Linux binary artifacts
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: linux-p7zip.7z
+          file: linux-p7zip.*
           asset_name: linux-p7zip
           tag: ${{ github.ref }}
           overwrite: true
+          file_glob: true
           body: "This is linux binary release using make"
 
   macos:
@@ -122,15 +124,17 @@ jobs:
              bash check_7za.sh `pwd`/../bin/7za
              bash check_7zr.sh `pwd`/../bin/7zr
              cd ..
-             ./bin/7za a macos-p7zip.7z ./bin/* -y
+             ./bin/7za a macos-p7zip.7z ./bin/* -t7z -y
+             ./bin/7z a macos-p7zip.zip ./bin/* -tzip -y
       - name: Upload the macOS binary artifacts
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: macos-p7zip.7z
+          file: macos-p7zip.*
           asset_name: macos-p7zip
           tag: ${{ github.ref }}
           overwrite: true
+          file_glob: true
           body: "This is macos binary release using make"
 
   ubuntu-cmake:
@@ -188,15 +192,17 @@ jobs:
              bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
              cd ..
-             ./CPP/7zip/CMAKE/build/bin/7za a linux-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/* -y
+             ./CPP/7zip/CMAKE/build/bin/7za a linux-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* -t7z -y
+             ./CPP/7zip/CMAKE/build/bin/7z a linux-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* -tzip -y
       - name: Upload the cmake Linux binary artifacts
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: linux-compatibly-p7zip.7z
+          file: linux-compatibly-p7zip.*
           asset_name: linux-compatibly-p7zip
           tag: ${{ github.ref }}
           overwrite: true
+          file_glob: true
           body: "This is linux binary release using cmake"
 
   macos-cmake:
@@ -254,13 +260,15 @@ jobs:
              bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
              cd ..
-             ./CPP/7zip/CMAKE/build/bin/7za a macos-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/* -y
+             ./CPP/7zip/CMAKE/build/bin/7za a macos-compatibly-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* -t7z -y
+             ./CPP/7zip/CMAKE/build/bin/7z a macos-compatibly-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* -tzip -y
       - name: Upload the cmake macOS binary artifacts
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: macos-compatibly-p7zip.7z
+          file: macos-compatibly-p7zip.*
           asset_name: macos-compatibly-p7zip
           tag: ${{ github.ref }}
           overwrite: true
+          file_glob: true
           body: "This is macos binary release using cmake"


### PR DESCRIPTION
In reference to https://github.com/jinfeihan57/p7zip/issues/105.

Having a Apple Mac is not necessary, the binaries are already being produced and tested on macOS platform. It seems the project here was uploading the binaries, when there is really no need for that, plus this is more secure.