### PR TITLE
7Zip -> 7zip in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We use [silesia](http://sun.aei.polsl.pl/~sdeor/index.php?page=silesia) files(to
 ```
 3. OR Using cmake directly:
 ```
-   cd p7zip/CPP/7Zip/CMAKE/ && mkdir build && cd build
+   cd p7zip/CPP/7zip/CMAKE/ && mkdir build && cd build
    cmake ..
    make 
 ```


### PR DESCRIPTION
Simply copy pasting the installation hint in README.md give me error, and I found that it is because the wrong case of 7Zip in README.md.   
Therefore, here is a fix of that.