### PR TITLE
update GitHub Actions to split CI builds and badge status for each platform

### DIFF
--- a/.github/workflows/linux- build.yml
+++ b/.github/workflows/linux- build.yml
@@ -1,0 +1,112 @@
+name: linux
+
+on: [push, pull_request]
+
+jobs:
+  ubuntu:
+    name: ubuntu-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: build 7za & test
+        run: |
+             make 7za
+             cd ./bin
+             ./7za a ta.7z ../CPP
+             ./7za x ta.7z
+             echo "compare file"
+             diff -r ../CPP ./CPP
+             echo "delete tmp file"
+             rm -rf ./ta.7z ./CPP
+             cd ..
+
+      - name: build 7zr & test
+        run: |
+             make 7zr
+             cd ./bin
+             ./7zr a tr.7z ../CPP
+             ./7zr x tr.7z
+             echo "compare file"
+             diff -r ../CPP ./CPP
+             echo "delete tmp file"
+             rm -rf ./tr.7z ./CPP
+             cd ..
+
+      - name: build 7z & test
+        run: |
+             make 7z
+             cd ./bin
+             ./7z a t.7z ../CPP
+             ./7z x t.7z
+             echo "compare file"
+             diff -r ../CPP ./CPP
+             echo "delete tmp file"
+             rm -rf ./t.7z ./CPP
+             cd ..
+
+      - name: build sfx
+        run: |
+             make sfx
+
+      - name: check
+        run: |
+             cd ./check
+             bash check.sh `pwd`/../bin/7z
+             bash check_7za.sh `pwd`/../bin/7za
+             bash check_7zr.sh `pwd`/../bin/7zr
+             cd ..
+
+  ubuntu-cmake:
+    name: ubuntu-cmake-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: cmake build 7z_ & test
+        run: |
+             cd ./CPP/7zip/CMAKE/
+             rm -rf ./build
+             mkdir build
+             cd build
+             cmake ..
+             make 7z_
+             make 7z
+             make Rar
+             make 7zCon.sfx
+             cd ./bin
+             ./7z_ a t_.7z ../../../Archive
+             ./7z_ x t_.7z
+             echo "compare file"
+             diff -r ../../../Archive ./Archive
+             echo "delte tmp file"
+             rm -rf t_.7z Archive
+
+      - name: cmake build 7za & test
+        run: |
+             cd ./CPP/7zip/CMAKE/build/
+             make 7za
+             cd ./bin
+             ./7za a ta.7z ../../../Archive
+             ./7za x ta.7z
+             echo "compare file"
+             diff -r ../../../Archive ./Archive
+             echo "delete tmp file"
+             rm -rf ta.7z Archive
+
+      - name: cmake build 7zr & test
+        run: |
+             cd ./CPP/7zip/CMAKE/build/
+             make 7zr
+             cd ./bin
+             ./7zr a tr.7z ../../../Archive
+             ./7zr x tr.7z
+             echo "compare file"
+             diff -r ../../../Archive ./Archive
+             echo "delete tmp file"
+             rm -rf tr.7z Archive
+
+      - name: check
+        run: |
+             cd ./check
+             bash ./check.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7z_
+             bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
+             bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,60 +1,8 @@
-name: BUILD
+name: macos
 
 on: [push, pull_request]
 
 jobs:
-  ubuntu:
-    name: ubuntu-build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: build 7za & test
-        run: |
-             make 7za
-             cd ./bin
-             ./7za a ta.7z ../CPP
-             ./7za x ta.7z
-             echo "compare file"
-             diff -r ../CPP ./CPP
-             echo "delete tmp file"
-             rm -rf ./ta.7z ./CPP
-             cd ..
-
-      - name: build 7zr & test
-        run: |
-             make 7zr
-             cd ./bin
-             ./7zr a tr.7z ../CPP
-             ./7zr x tr.7z
-             echo "compare file"
-             diff -r ../CPP ./CPP
-             echo "delete tmp file"
-             rm -rf ./tr.7z ./CPP
-             cd ..
-
-      - name: build 7z & test
-        run: |
-             make 7z
-             cd ./bin
-             ./7z a t.7z ../CPP
-             ./7z x t.7z
-             echo "compare file"
-             diff -r ../CPP ./CPP
-             echo "delete tmp file"
-             rm -rf ./t.7z ./CPP
-             cd ..
-
-      - name: build sfx
-        run: |
-             make sfx
-
-      - name: check
-        run: |
-             cd ./check
-             bash check.sh `pwd`/../bin/7z
-             bash check_7za.sh `pwd`/../bin/7za
-             bash check_7zr.sh `pwd`/../bin/7zr
-             cd ..
   macos:
     name: macos-build
     runs-on: macos-latest
@@ -108,61 +56,6 @@ jobs:
              bash check_7za.sh `pwd`/../bin/7za
              bash check_7zr.sh `pwd`/../bin/7zr
              cd ..
-
-  ubuntu-cmake:
-    name: ubuntu-cmake-build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: cmake build 7z_ & test
-        run: |
-             cd ./CPP/7zip/CMAKE/
-             rm -rf ./build
-             mkdir build
-             cd build
-             cmake ..
-             make 7z_
-             make 7z
-             make Rar
-             make 7zCon.sfx
-             cd ./bin
-             ./7z_ a t_.7z ../../../Archive
-             ./7z_ x t_.7z
-             echo "compare file"
-             diff -r ../../../Archive ./Archive
-             echo "delte tmp file"
-             rm -rf t_.7z Archive
-
-      - name: cmake build 7za & test
-        run: |
-             cd ./CPP/7zip/CMAKE/build/
-             make 7za
-             cd ./bin
-             ./7za a ta.7z ../../../Archive
-             ./7za x ta.7z
-             echo "compare file"
-             diff -r ../../../Archive ./Archive
-             echo "delete tmp file"
-             rm -rf ta.7z Archive
-
-      - name: cmake build 7zr & test
-        run: |
-             cd ./CPP/7zip/CMAKE/build/
-             make 7zr
-             cd ./bin
-             ./7zr a tr.7z ../../../Archive
-             ./7zr x tr.7z
-             echo "compare file"
-             diff -r ../../../Archive ./Archive
-             echo "delete tmp file"
-             rm -rf tr.7z Archive
-
-      - name: check
-        run: |
-             cd ./check
-             bash ./check.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7z_
-             bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
-             bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
 
   macos-cmake:
     name: macos-cmake-build

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,0 +1,143 @@
+name: release-linux
+
+on:
+  release:
+    tags:
+      - '*'
+
+jobs:
+  ubuntu:
+    name: ubuntu-binary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: build 7za & test
+        run: |
+             make 7za
+             cd ./bin
+             ./7za a ta.7z ../CPP
+             ./7za x ta.7z
+             echo "compare file"
+             diff -r ../CPP ./CPP
+             echo "delete tmp file"
+             rm -rf ./ta.7z ./CPP
+             cd ..
+
+      - name: build 7zr & test
+        run: |
+             make 7zr
+             cd ./bin
+             ./7zr a tr.7z ../CPP
+             ./7zr x tr.7z
+             echo "compare file"
+             diff -r ../CPP ./CPP
+             echo "delete tmp file"
+             rm -rf ./tr.7z ./CPP
+             cd ..
+
+      - name: build 7z & test
+        run: |
+             make 7z
+             cd ./bin
+             ./7z a t.7z ../CPP
+             ./7z x t.7z
+             echo "compare file"
+             diff -r ../CPP ./CPP
+             echo "delete tmp file"
+             rm -rf ./t.7z ./CPP
+             cd ..
+
+      - name: build sfx
+        run: |
+             make sfx
+
+      - name: check
+        run: |
+             cd ./check
+             bash check.sh `pwd`/../bin/7z
+             bash check_7za.sh `pwd`/../bin/7za
+             bash check_7zr.sh `pwd`/../bin/7zr
+             cd ..
+             ./bin/7za a linux-p7zip.7z ./bin/* -t7z -y
+             ./bin/7z a linux-p7zip.zip ./bin/* -tzip -y
+      - name: Upload the Linux binary artifacts
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: linux-p7zip.*
+          asset_name: linux-p7zip
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
+          body: "This is linux binary release using make"
+
+  ubuntu-cmake:
+    name: ubuntu-cmake-binary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: cmake build 7z_ & test
+        run: |
+             cd ./CPP/7zip/CMAKE/
+             rm -rf ./build
+             mkdir build
+             cd build
+             cmake ..
+             make 7z_
+             make 7z
+             make Rar
+             make 7zCon.sfx
+             cd ./bin
+             ./7z_ a t_.7z ../../../Archive
+             ./7z_ x t_.7z
+             echo "compare file"
+             diff -r ../../../Archive ./Archive
+             echo "delte tmp file"
+             rm -rf t_.7z Archive
+
+      - name: cmake build 7za & test
+        run: |
+             cd ./CPP/7zip/CMAKE/build/
+             make 7za
+             cd ./bin
+             ./7za a ta.7z ../../../Archive
+             ./7za x ta.7z
+             echo "compare file"
+             diff -r ../../../Archive ./Archive
+             echo "delete tmp file"
+             rm -rf ta.7z Archive
+
+      - name: cmake build 7zr & test
+        run: |
+             cd ./CPP/7zip/CMAKE/build/
+             make 7zr
+             cd ./bin
+             ./7zr a tr.7z ../../../Archive
+             ./7zr x tr.7z
+             echo "compare file"
+             diff -r ../../../Archive ./Archive
+             echo "delete tmp file"
+             rm -rf tr.7z Archive
+
+      - name: check
+        run: |
+             cd ./check
+             bash ./check.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7z_
+             bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
+             bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
+             cd ..
+             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/CMakeFiles
+             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/Makefile
+             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/cmake_install.cmake
+             ./CPP/7zip/CMAKE/build/bin/7za a linux-cmake-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
+             ./CPP/7zip/CMAKE/build/bin/7z_ a linux-cmake-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
+      - name: Upload the cmake Linux binary artifacts
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: linux-cmake-p7zip.*
+          asset_name: linux-cmake-p7zip
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
+          body: "This is linux binary release using cmake"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -61,17 +61,17 @@ jobs:
              cd ..
       - name: Get runner environment variables
         id: runner
-        uses: msansoni/runner-environment-action@v1
+        uses: techno-express/action-environment-info@v1
       - name: Create 7z & Zip binary archive from build
         run: |
-             ./bin/7za a ${{ format('{0}-{1}-p7zip.7z', steps.runner.outputs.platform, steps.runner.outputs.arch) }} ./bin/* -t7z -y
-             ./bin/7z a ${{ format('{0}-{1}-p7zip.zip', steps.runner.outputs.platform, steps.runner.outputs.arch) }} ./bin/* -tzip -y
+             ./bin/7za a ${{ format('macos-{0}-p7zip.7z', steps.runner.outputs.release) }} ./bin/* -t7z -y
+             ./bin/7z a ${{ format('macos-{0}-p7zip.zip', steps.runner.outputs.release) }} ./bin/* -tzip -y
       - name: Upload the macOS binary artifacts
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ format('{0}-{1}-p7zip.*', steps.runner.outputs.platform, steps.runner.outputs.arch) }}
-          asset_name: ${{ format('{0}-{1}-p7zip', steps.runner.outputs.platform, steps.runner.outputs.arch) }}
+          file: ${{ format('macos-{0}-p7zip.*', steps.runner.outputs.release) }}
+          asset_name: ${{ format('macos-{0}-p7zip', steps.runner.outputs.release) }}
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true
@@ -134,20 +134,20 @@ jobs:
              cd ..
       - name: Get runner environment variables
         id: runner
-        uses: msansoni/runner-environment-action@v1
+        uses: techno-express/action-environment-info@v1
       - name: Create 7z & Zip binary archive from build
         run: |
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/CMakeFiles
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/Makefile
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/cmake_install.cmake
-             ./CPP/7zip/CMAKE/build/bin/7za a ${{ format('{0}-{1}-cmake-p7zip.7z', steps.runner.outputs.platform, steps.runner.outputs.arch) }} ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
-             ./CPP/7zip/CMAKE/build/bin/7z_ a ${{ format('{0}-{1}-cmake-p7zip.zip', steps.runner.outputs.platform, steps.runner.outputs.arch) }} ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
+             ./CPP/7zip/CMAKE/build/bin/7za a ${{ format('macos-{0}-cmake-p7zip.7z', steps.runner.outputs.release) }} ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
+             ./CPP/7zip/CMAKE/build/bin/7z_ a ${{ format('macos-{0}-cmake-p7zip.zip', steps.runner.outputs.release) }} ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
       - name: Upload the cmake macOS binary artifacts
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ format('{0}-{1}-cmake-p7zip.*', steps.runner.outputs.platform, steps.runner.outputs.arch) }}
-          asset_name: ${{ format('{0}-{1}-cmake-p7zip', steps.runner.outputs.platform, steps.runner.outputs.arch) }}
+          file: ${{ format('macos-{0}-cmake-p7zip.*', steps.runner.outputs.release) }}
+          asset_name: ${{ format('macos-{0}-cmake-p7zip', steps.runner.outputs.release) }}
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -59,12 +59,19 @@ jobs:
              bash check_7za.sh `pwd`/../bin/7za
              bash check_7zr.sh `pwd`/../bin/7zr
              cd ..
-             ./bin/7za a macos-p7zip.7z ./bin/* -t7z -y
-             ./bin/7z a macos-p7zip.zip ./bin/* -tzip -y
+      - name: Get runner environment variables
+        id: runner
+        uses: msansoni/runner-environment-action@v1
+      - name: Create 7z & Zip binary archive from build
+        run: |
+             ./bin/7za a ${{ format('{0}-{1}-p7zip.7z', steps.runner.outputs.platform, steps.runner.outputs.arch) }} ./bin/* -t7z -y
+             ./bin/7z a ${{ format('{0}-{1}-p7zip.zip', steps.runner.outputs.platform, steps.runner.outputs.arch) }} ./bin/* -tzip -y
       - name: Upload the macOS binary artifacts
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ format('{0}-{1}-p7zip.*', steps.runner.outputs.platform, steps.runner.outputs.arch) }}
+          asset_name: ${{ format('{0}-{1}-p7zip', steps.runner.outputs.platform, steps.runner.outputs.arch) }}
           file: macos-p7zip.*
           asset_name: macos-p7zip
           tag: ${{ github.ref }}
@@ -127,17 +134,22 @@ jobs:
              bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
              bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
              cd ..
+      - name: Get runner environment variables
+        id: runner
+        uses: msansoni/runner-environment-action@v1
+      - name: Create 7z & Zip binary archive from build
+        run: |
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/CMakeFiles
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/Makefile
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/cmake_install.cmake
-             ./CPP/7zip/CMAKE/build/bin/7za a macos-cmake-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
-             ./CPP/7zip/CMAKE/build/bin/7z_ a macos-cmake-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
+             ./CPP/7zip/CMAKE/build/bin/7za a ${{ format('{0}-{1}-cmake-p7zip.7z', steps.runner.outputs.platform, steps.runner.outputs.arch) }} ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
+             ./CPP/7zip/CMAKE/build/bin/7z_ a ${{ format('{0}-{1}-cmake-p7zip.zip', steps.runner.outputs.platform, steps.runner.outputs.arch) }} ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
       - name: Upload the cmake macOS binary artifacts
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: macos-cmake-p7zip.*
-          asset_name: macos-cmake-p7zip
+          file: ${{ format('{0}-{1}-cmake-p7zip.*', steps.runner.outputs.platform, steps.runner.outputs.arch) }}
+          asset_name: ${{ format('{0}-{1}-cmake-p7zip', steps.runner.outputs.platform, steps.runner.outputs.arch) }}
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -64,14 +64,14 @@ jobs:
         uses: techno-express/action-environment-info@1
       - name: Create 7z & Zip binary archive from build
         run: |
-             ./bin/7za a ${{ format('macos-{0}-p7zip.7z', steps.runner.outputs.release) }} ./bin/* -t7z -y
-             ./bin/7z a ${{ format('macos-{0}-p7zip.zip', steps.runner.outputs.release) }} ./bin/* -tzip -y
+             ./bin/7za a ${{ format('macos-{0}-p7zip.7z', steps.runner.outputs.version) }} ./bin/* -t7z -y
+             ./bin/7z a ${{ format('macos-{0}-p7zip.zip', steps.runner.outputs.version) }} ./bin/* -tzip -y
       - name: Upload the macOS binary artifacts
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ format('macos-{0}-p7zip.*', steps.runner.outputs.release) }}
-          asset_name: ${{ format('macos-{0}-p7zip', steps.runner.outputs.release) }}
+          file: ${{ format('macos-{0}-p7zip.*', steps.runner.outputs.version) }}
+          asset_name: ${{ format('macos-{0}-p7zip', steps.runner.outputs.version) }}
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true
@@ -140,14 +140,14 @@ jobs:
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/CMakeFiles
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/Makefile
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/cmake_install.cmake
-             ./CPP/7zip/CMAKE/build/bin/7za a ${{ format('macos-{0}-cmake-p7zip.7z', steps.runner.outputs.release) }} ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
-             ./CPP/7zip/CMAKE/build/bin/7z_ a ${{ format('macos-{0}-cmake-p7zip.zip', steps.runner.outputs.release) }} ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
+             ./CPP/7zip/CMAKE/build/bin/7za a ${{ format('macos-{0}-cmake-p7zip.7z', steps.runner.outputs.version) }} ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
+             ./CPP/7zip/CMAKE/build/bin/7z_ a ${{ format('macos-{0}-cmake-p7zip.zip', steps.runner.outputs.version) }} ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
       - name: Upload the cmake macOS binary artifacts
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ format('macos-{0}-cmake-p7zip.*', steps.runner.outputs.release) }}
-          asset_name: ${{ format('macos-{0}-cmake-p7zip', steps.runner.outputs.release) }}
+          file: ${{ format('macos-{0}-cmake-p7zip.*', steps.runner.outputs.version) }}
+          asset_name: ${{ format('macos-{0}-cmake-p7zip', steps.runner.outputs.version) }}
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -61,7 +61,7 @@ jobs:
              cd ..
       - name: Get runner environment variables
         id: runner
-        uses: techno-express/action-environment-info@v1
+        uses: techno-express/action-environment-info@1
       - name: Create 7z & Zip binary archive from build
         run: |
              ./bin/7za a ${{ format('macos-{0}-p7zip.7z', steps.runner.outputs.release) }} ./bin/* -t7z -y
@@ -134,7 +134,7 @@ jobs:
              cd ..
       - name: Get runner environment variables
         id: runner
-        uses: techno-express/action-environment-info@v1
+        uses: techno-express/action-environment-info@1
       - name: Create 7z & Zip binary archive from build
         run: |
              rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/CMakeFiles

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,4 +1,4 @@
-name: Release
+name: release-macos
 
 on:
   release:
@@ -6,71 +6,6 @@ on:
       - '*'
 
 jobs:
-  ubuntu:
-    name: ubuntu-binary
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: build 7za & test
-        run: |
-             make 7za
-             cd ./bin
-             ./7za a ta.7z ../CPP
-             ./7za x ta.7z
-             echo "compare file"
-             diff -r ../CPP ./CPP
-             echo "delete tmp file"
-             rm -rf ./ta.7z ./CPP
-             cd ..
-
-      - name: build 7zr & test
-        run: |
-             make 7zr
-             cd ./bin
-             ./7zr a tr.7z ../CPP
-             ./7zr x tr.7z
-             echo "compare file"
-             diff -r ../CPP ./CPP
-             echo "delete tmp file"
-             rm -rf ./tr.7z ./CPP
-             cd ..
-
-      - name: build 7z & test
-        run: |
-             make 7z
-             cd ./bin
-             ./7z a t.7z ../CPP
-             ./7z x t.7z
-             echo "compare file"
-             diff -r ../CPP ./CPP
-             echo "delete tmp file"
-             rm -rf ./t.7z ./CPP
-             cd ..
-
-      - name: build sfx
-        run: |
-             make sfx
-
-      - name: check
-        run: |
-             cd ./check
-             bash check.sh `pwd`/../bin/7z
-             bash check_7za.sh `pwd`/../bin/7za
-             bash check_7zr.sh `pwd`/../bin/7zr
-             cd ..
-             ./bin/7za a linux-p7zip.7z ./bin/* -t7z -y
-             ./bin/7z a linux-p7zip.zip ./bin/* -tzip -y
-      - name: Upload the Linux binary artifacts
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: linux-p7zip.*
-          asset_name: linux-p7zip
-          tag: ${{ github.ref }}
-          overwrite: true
-          file_glob: true
-          body: "This is linux binary release using make"
-
   macos:
     name: macos-binary
     runs-on: macos-latest
@@ -136,77 +71,6 @@ jobs:
           overwrite: true
           file_glob: true
           body: "This is macos binary release using make"
-
-  ubuntu-cmake:
-    name: ubuntu-cmake-binary
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: cmake build 7z_ & test
-        run: |
-             cd ./CPP/7zip/CMAKE/
-             rm -rf ./build
-             mkdir build
-             cd build
-             cmake ..
-             make 7z_
-             make 7z
-             make Rar
-             make 7zCon.sfx
-             cd ./bin
-             ./7z_ a t_.7z ../../../Archive
-             ./7z_ x t_.7z
-             echo "compare file"
-             diff -r ../../../Archive ./Archive
-             echo "delte tmp file"
-             rm -rf t_.7z Archive
-
-      - name: cmake build 7za & test
-        run: |
-             cd ./CPP/7zip/CMAKE/build/
-             make 7za
-             cd ./bin
-             ./7za a ta.7z ../../../Archive
-             ./7za x ta.7z
-             echo "compare file"
-             diff -r ../../../Archive ./Archive
-             echo "delete tmp file"
-             rm -rf ta.7z Archive
-
-      - name: cmake build 7zr & test
-        run: |
-             cd ./CPP/7zip/CMAKE/build/
-             make 7zr
-             cd ./bin
-             ./7zr a tr.7z ../../../Archive
-             ./7zr x tr.7z
-             echo "compare file"
-             diff -r ../../../Archive ./Archive
-             echo "delete tmp file"
-             rm -rf tr.7z Archive
-
-      - name: check
-        run: |
-             cd ./check
-             bash ./check.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7z_
-             bash ./check_7za.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7za
-             bash ./check_7zr.sh `pwd`/../CPP/7zip/CMAKE/build/bin/7zr
-             cd ..
-             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/CMakeFiles
-             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/Makefile
-             rm -rf ./CPP/7zip/CMAKE/build/bin/Codecs/cmake_install.cmake
-             ./CPP/7zip/CMAKE/build/bin/7za a linux-cmake-p7zip.7z ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -t7z -y
-             ./CPP/7zip/CMAKE/build/bin/7z_ a linux-cmake-p7zip.zip ./CPP/7zip/CMAKE/build/bin/7z* ./CPP/7zip/CMAKE/build/bin/Codecs -tzip -y
-      - name: Upload the cmake Linux binary artifacts
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: linux-cmake-p7zip.*
-          asset_name: linux-cmake-p7zip
-          tag: ${{ github.ref }}
-          overwrite: true
-          file_glob: true
-          body: "This is linux binary release using cmake"
 
   macos-cmake:
     name: macos-cmake-binary

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -72,8 +72,6 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ format('{0}-{1}-p7zip.*', steps.runner.outputs.platform, steps.runner.outputs.arch) }}
           asset_name: ${{ format('{0}-{1}-p7zip', steps.runner.outputs.platform, steps.runner.outputs.arch) }}
-          file: macos-p7zip.*
-          asset_name: macos-p7zip
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This is the place for the active development of p7zip to include major modern codecs such as Brotli, Fast LZMA2, LZ4, LZ5, Lizard and Zstd. In order to support multithreading for those addional codecs, this project depends on the [Multithreading Library](https://github.com/mcmilk/zstdmt).
 
 # status Ubuntu && mac
-[![Linux](https://github.com/jinfeihan57/p7zip/workflows/linux/badge.svg)](https://github.com/jinfeihan57/p7zip/actions?query=workflow%3Alinux)[![macOS](https://github.com/jinfeihan57/p7zip/workflows/macos/badge.svg)](https://github.com/jinfeihan57/p7zip/actions?query=workflow%3Amacos)
+[![linux](https://github.com/jinfeihan57/p7zip/actions/workflows/linux-%20build.yml/badge.svg)](https://github.com/jinfeihan57/p7zip/actions/workflows/linux-%20build.yml)[![macos](https://github.com/jinfeihan57/p7zip/actions/workflows/macos-build.yml/badge.svg)](https://github.com/jinfeihan57/p7zip/actions/workflows/macos-build.yml)
 
 ## Codec overview
 1. [Zstandard] v1.4.8 is a real-time compression algorithm, providing high compression ratios. It offers a very wide range of compression / speed trade-off, while being backed by a very fast decoder.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 This is the place for the active development of p7zip to include major modern codecs such as Brotli, Fast LZMA2, LZ4, LZ5, Lizard and Zstd. In order to support multithreading for those addional codecs, this project depends on the [Multithreading Library](https://github.com/mcmilk/zstdmt).
 
 # status Ubuntu && mac
-![BUILD](https://github.com/jinfeihan57/p7zip/workflows/BUILD/badge.svg)
+[![Linux](https://github.com/jinfeihan57/p7zip/workflows/linux/badge.svg)](https://github.com/jinfeihan57/p7zip/actions?query=workflow%3Alinux)[![macOS](https://github.com/jinfeihan57/p7zip/workflows/macos/badge.svg)](https://github.com/jinfeihan57/p7zip/actions?query=workflow%3Amacos)
+
 ## Codec overview
 1. [Zstandard] v1.4.8 is a real-time compression algorithm, providing high compression ratios. It offers a very wide range of compression / speed trade-off, while being backed by a very fast decoder.
    - Levels: 1..19
@@ -26,9 +27,9 @@ This is the place for the active development of p7zip to include major modern co
    - Levels 20..29 (LIZv1) are designed to give better ratio than LZ4 keeping 75% decompression speed
    - Levels 30..39 (fastLZ4 + Huffman) adds Huffman coding to fastLZ4
    - Levels 40..49 (LIZv1 + Huffman) give the best ratio, comparable to zlib and low levels of zstd/brotli, but with a faster decompression speed
-   
+
 ## Benchmark
-We use [silesia](http://sun.aei.polsl.pl/~sdeor/index.php?page=silesia) files(total size 211938580 Byte) for packaging. 
+We use [silesia](http://sun.aei.polsl.pl/~sdeor/index.php?page=silesia) files(total size 211938580 Byte) for packaging.
    CPU frequency：2.60GHz
 |format|method|encode_size(Byte)|encode_time(ms)|encode_speed(M/s)|decode_time(ms)|decode_speed(M/s)|compression_ratio|
 |:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
@@ -58,16 +59,16 @@ We use [silesia](http://sun.aei.polsl.pl/~sdeor/index.php?page=silesia) files(to
 ```
    cd p7zip/CPP/7zip/CMAKE/ && mkdir build && cd build
    cmake ..
-   make 
+   make
 ```
 4. Test:
 ```
-   ./bin/7z i 
+   ./bin/7z i
 ```
 
 The output should look like this:
 ```
-7-Zip (a) [64] 17.03 : Copyright (c) 1999-2020 Igor Pavlov 
+7-Zip (a) [64] 17.03 : Copyright (c) 1999-2020 Igor Pavlov
 p7zip Version 17.03 (locale=zh_CN.UTF-8,Utf16=on,HugeFiles=on,64 bits,12 CPUs x64)
 
 Formats:
@@ -150,7 +151,7 @@ Hashers:
   - [Brotli] Version v1.0.9
   - [LZ5] Version v1.5
   - [Lizard] Version 1.0
-  
+
 ## Working Plan
  - [check here]()
 


### PR DESCRIPTION
Will update once i find out good way to detect in CI actual OS/platform without hard including, in reference to https://github.com/jinfeihan57/p7zip/issues/120.