### PR TITLE
add lzip decompression support

### DIFF
--- a/CPP/7zip/Archive/7z/7zUpdate.cpp
+++ b/CPP/7zip/Archive/7z/7zUpdate.cpp
@@ -558,7 +558,7 @@ static int CompareEmptyItems(const unsigned *p1, const unsigned *p2, void *param
 }
 
 static const char *g_Exts =
-  " 7z xz lzma ace arc arj bz tbz bz2 tbz2 cab deb gz tgz ha lha lz4 tlz4 lzh lzo lzx pak rar rpm sit zoo zst"
+  " 7z xz lzma ace arc arj bz tbz bz2 tbz2 cab deb gz tgz ha lha lz tlz lz4 tlz4 lzh lzo lzx pak rar rpm sit zoo zst"
   " zip jar ear war msi"
   " 3gp avi mov mpeg mpg mpe wmv"
   " aac ape fla flac la mp3 m4a mp4 ofr ogg pac ra rm rka shn swa tta wv wma wav"

--- a/CPP/7zip/Archive/IArchive.h
+++ b/CPP/7zip/Archive/IArchive.h
@@ -155,7 +155,7 @@ IArchiveExtractCallback::GetStream()
 if (IProgress::SetTotal() was called)
 {
   IProgress::SetCompleted(completeValue) uses
-    packSize   - for some stream formats (xz, gz, bz2, lzma, z, ppmd).
+    packSize   - for some stream formats (xz, gz, bz2, lz, lzma, z, ppmd).
     unpackSize - for another formats.
 }
 else

--- a/CPP/7zip/Archive/LzHandler.cpp
+++ b/CPP/7zip/Archive/LzHandler.cpp
@@ -1,0 +1,460 @@
+// LzHandler.cpp
+
+#include "StdAfx.h"
+
+#include "../../../C/CpuArch.h"
+
+#include "../../Common/ComTry.h"
+#include "../../Common/IntToString.h"
+
+#include "../../Windows/PropVariant.h"
+
+#include "../Common/ProgressUtils.h"
+#include "../Common/RegisterArc.h"
+#include "../Common/StreamUtils.h"
+
+#include "../Compress/LzmaDecoder.h"
+
+#include "Common/OutStreamWithCRC.h"
+
+using namespace NWindows;
+
+namespace NArchive {
+namespace NLz {
+
+static const Byte kProps[] =
+{
+  kpidSize,
+  kpidPackSize,
+};
+
+static const Byte kArcProps[] =
+{
+  kpidNumStreams
+};
+
+static const Byte k_Signature[5] = { 'L', 'Z', 'I', 'P', 1 };
+enum { k_SignatureSize = 5 };
+
+struct CHeader
+{
+  Byte data[6];		// 0-3 magic bytes, 4 version, 5 coded_dict_size
+  enum { size = 6 };
+  enum { min_dictionary_size = 1 << 12, max_dictionary_size = 1 << 29 };
+  unsigned DicSize;
+  Byte LzmaProps[5];
+
+  bool Parse();
+};
+
+struct CTrailer
+{
+  Byte data[20];	//  0-3  CRC32 of the uncompressed data
+			//  4-11 size of the uncompressed data
+			// 12-19 member size including header and trailer
+  enum { size = 20 };
+
+  unsigned data_crc() const
+    {
+    unsigned tmp = 0;
+    for( int i = 3; i >= 0; --i ) { tmp <<= 8; tmp += data[i]; }
+    return tmp;
+    }
+
+  UInt64 data_size() const
+    {
+    UInt64 tmp = 0;
+    for( int i = 11; i >= 4; --i ) { tmp <<= 8; tmp += data[i]; }
+    return tmp;
+    }
+
+  UInt64 member_size() const
+    {
+    UInt64 tmp = 0;
+    for( int i = 19; i >= 12; --i ) { tmp <<= 8; tmp += data[i]; }
+    return tmp;
+    }
+};
+
+class CDecoder
+{
+  CMyComPtr<ICompressCoder> _lzmaDecoder;
+public:
+  NCompress::NLzma::CDecoder *_lzmaDecoderSpec;
+
+  ~CDecoder();
+  HRESULT Create(ISequentialInStream *inStream);
+
+  HRESULT Code(const CHeader &header, ISequentialOutStream *outStream, ICompressProgressInfo *progress);
+
+  UInt64 GetInputProcessedSize() const { return _lzmaDecoderSpec->GetInputProcessedSize(); }
+
+  void ReleaseInStream() { if (_lzmaDecoder) _lzmaDecoderSpec->ReleaseInStream(); }
+
+  HRESULT ReadInput(Byte *data, UInt32 size, UInt32 *processedSize)
+    { return _lzmaDecoderSpec->ReadFromInputStream(data, size, processedSize); }
+};
+
+HRESULT CDecoder::Create(ISequentialInStream *inStream)
+{
+  if (!_lzmaDecoder)
+  {
+    _lzmaDecoderSpec = new NCompress::NLzma::CDecoder;
+    _lzmaDecoderSpec->FinishStream = true;
+    _lzmaDecoder = _lzmaDecoderSpec;
+  }
+
+  return _lzmaDecoderSpec->SetInStream(inStream);
+}
+
+CDecoder::~CDecoder()
+{
+  ReleaseInStream();
+}
+
+HRESULT CDecoder::Code(const CHeader &header, ISequentialOutStream *outStream,
+    ICompressProgressInfo *progress)
+{
+  {
+    CMyComPtr<ICompressSetDecoderProperties2> setDecoderProperties;
+    _lzmaDecoder.QueryInterface(IID_ICompressSetDecoderProperties2, &setDecoderProperties);
+    if (!setDecoderProperties)
+      return E_NOTIMPL;
+    RINOK(setDecoderProperties->SetDecoderProperties2(header.LzmaProps, 5));
+  }
+
+  RINOK(_lzmaDecoderSpec->CodeResume(outStream, NULL, progress));
+
+  return S_OK;
+}
+
+
+class CHandler:
+  public IInArchive,
+  public IArchiveOpenSeq,
+  public CMyUnknownImp
+{
+  CHeader _header;
+  CMyComPtr<IInStream> _stream;
+  CMyComPtr<ISequentialInStream> _seqStream;
+
+  bool _isArc;
+  bool _needSeekToStart;
+  bool _dataAfterEnd;
+  bool _needMoreInput;
+
+  bool _packSize_Defined;
+  bool _unpackSize_Defined;
+  bool _numStreams_Defined;
+
+  bool _dataError;
+
+  UInt64 _packSize;
+  UInt64 _unpackSize;
+  UInt64 _numStreams;
+
+public:
+  MY_UNKNOWN_IMP2(IInArchive, IArchiveOpenSeq)
+
+  INTERFACE_IInArchive(;)
+  STDMETHOD(OpenSeq)(ISequentialInStream *stream);
+
+  CHandler() { }
+};
+
+IMP_IInArchive_Props
+IMP_IInArchive_ArcProps
+
+STDMETHODIMP CHandler::GetArchiveProperty(PROPID propID, PROPVARIANT *value)
+{
+  NCOM::CPropVariant prop;
+  switch (propID)
+  {
+    case kpidPhySize: if (_packSize_Defined) prop = _packSize; break;
+    case kpidUnpackSize: if (_unpackSize_Defined) prop = _unpackSize; break;
+    case kpidNumStreams: if (_numStreams_Defined) prop = _numStreams; break;
+    case kpidErrorFlags:
+    {
+      UInt32 v = 0;
+      if (!_isArc) v |= kpv_ErrorFlags_IsNotArc;;
+      if (_needMoreInput) v |= kpv_ErrorFlags_UnexpectedEnd;
+      if (_dataAfterEnd) v |= kpv_ErrorFlags_DataAfterEnd;
+      if (_dataError) v |= kpv_ErrorFlags_DataError;
+      prop = v;
+    }
+  }
+  prop.Detach(value);
+  return S_OK;
+}
+
+STDMETHODIMP CHandler::GetNumberOfItems(UInt32 *numItems)
+{
+  *numItems = 1;
+  return S_OK;
+}
+
+STDMETHODIMP CHandler::GetProperty(UInt32 /* index */, PROPID propID, PROPVARIANT *value)
+{
+  NCOM::CPropVariant prop;
+  switch (propID)
+  {
+    case kpidSize: if (_unpackSize_Defined) prop = _unpackSize; break;
+    case kpidPackSize: if (_packSize_Defined) prop = _packSize; break;
+  }
+  prop.Detach(value);
+  return S_OK;
+}
+
+API_FUNC_static_IsArc IsArc_Lz(const Byte *p, size_t size)
+{
+  if (size < k_SignatureSize)
+    return k_IsArc_Res_NEED_MORE;
+  for( int i = 0; i < k_SignatureSize; ++i )
+    if( p[i] != k_Signature[i] )
+      return k_IsArc_Res_NO;
+  return k_IsArc_Res_YES;
+}
+}
+
+bool CHeader::Parse()
+{
+  if (IsArc_Lz(data, k_SignatureSize) == k_IsArc_Res_NO)
+    return false;
+  DicSize = ( 1 << ( data[5] & 0x1F ) );
+  if( DicSize > min_dictionary_size )
+    DicSize -= ( DicSize / 16 ) * ( ( data[5] >> 5 ) & 7 );
+  LzmaProps[0] = 93;			/* (45 * 2) + (9 * 0) + 3 */
+  unsigned ds = DicSize;
+  for( int i = 1; i <= 4; ++i ) { LzmaProps[i] = ds & 0xFF; ds >>= 8; }
+  return (DicSize >= min_dictionary_size && DicSize <= max_dictionary_size);
+}
+
+STDMETHODIMP CHandler::Open(IInStream *inStream, const UInt64 *, IArchiveOpenCallback *)
+{
+  Close();
+
+  RINOK(ReadStream_FALSE(inStream, _header.data, CHeader::size));
+
+  if (!_header.Parse())
+    return S_FALSE;
+
+  RINOK(inStream->Seek(0, STREAM_SEEK_END, &_packSize));
+  if (_packSize < 36)
+    return S_FALSE;
+  _isArc = true;
+  _stream = inStream;
+  _seqStream = inStream;
+  _needSeekToStart = true;
+  return S_OK;
+}
+
+STDMETHODIMP CHandler::OpenSeq(ISequentialInStream *stream)
+{
+  Close();
+  _isArc = true;
+  _seqStream = stream;
+  return S_OK;
+}
+
+STDMETHODIMP CHandler::Close()
+{
+  _isArc = false;
+  _packSize_Defined = false;
+  _unpackSize_Defined = false;
+  _numStreams_Defined = false;
+
+  _dataAfterEnd = false;
+  _needMoreInput = false;
+  _dataError = false;
+
+  _packSize = 0;
+
+  _needSeekToStart = false;
+
+  _stream.Release();
+  _seqStream.Release();
+   return S_OK;
+}
+
+class CCompressProgressInfoImp:
+  public ICompressProgressInfo,
+  public CMyUnknownImp
+{
+  CMyComPtr<IArchiveOpenCallback> Callback;
+public:
+  UInt64 Offset;
+
+  MY_UNKNOWN_IMP1(ICompressProgressInfo)
+  STDMETHOD(SetRatioInfo)(const UInt64 *inSize, const UInt64 *outSize);
+  void Init(IArchiveOpenCallback *callback) { Callback = callback; }
+};
+
+STDMETHODIMP CCompressProgressInfoImp::SetRatioInfo(const UInt64 *inSize, const UInt64 * /* outSize */)
+{
+  if (Callback)
+  {
+    UInt64 files = 0;
+    UInt64 value = Offset + *inSize;
+    return Callback->SetCompleted(&files, &value);
+  }
+  return S_OK;
+}
+
+STDMETHODIMP CHandler::Extract(const UInt32 *indices, UInt32 numItems,
+    Int32 testMode, IArchiveExtractCallback *extractCallback)
+{
+  COM_TRY_BEGIN
+  if (numItems == 0)
+    return S_OK;
+  if (numItems != (UInt32)(Int32)-1 && (numItems != 1 || indices[0] != 0))
+    return E_INVALIDARG;
+
+  if (_packSize_Defined)
+    extractCallback->SetTotal(_packSize);
+
+  CMyComPtr<ISequentialOutStream> realOutStream;
+  Int32 askMode = testMode ?
+      NExtract::NAskMode::kTest :
+      NExtract::NAskMode::kExtract;
+  RINOK(extractCallback->GetStream(0, &realOutStream, askMode));
+  if (!testMode && !realOutStream)
+    return S_OK;
+
+  extractCallback->PrepareOperation(askMode);
+
+  COutStreamWithCRC *outStreamSpec = new COutStreamWithCRC;
+  CMyComPtr<ISequentialOutStream> outStream(outStreamSpec);
+  outStreamSpec->SetStream(realOutStream);
+  outStreamSpec->Init();
+  realOutStream.Release();
+
+  CLocalProgress *lps = new CLocalProgress;
+  CMyComPtr<ICompressProgressInfo> progress = lps;
+  lps->Init(extractCallback, true);
+
+  if (_needSeekToStart)
+  {
+    if (!_stream)
+      return E_FAIL;
+    RINOK(_stream->Seek(0, STREAM_SEEK_SET, NULL));
+  }
+  else
+    _needSeekToStart = true;
+
+  CDecoder decoder;
+  HRESULT result = decoder.Create(_seqStream);
+  RINOK(result);
+
+  bool firstItem = true;
+
+  UInt64 packSize = 0;
+  UInt64 unpackSize = 0;
+  UInt64 numStreams = 0;
+
+  bool crcError = false;
+  bool dataAfterEnd = false;
+
+  for (;;)
+  {
+    lps->InSize = packSize;
+    lps->OutSize = unpackSize;
+    RINOK(lps->SetCur());
+
+    CHeader st;
+    UInt32 processed;
+    RINOK(decoder.ReadInput(st.data, CHeader::size, &processed));
+    if (processed != CHeader::size)
+    {
+      if (processed != 0)
+        dataAfterEnd = true;
+      break;
+    }
+
+    if (!st.Parse())
+    {
+      dataAfterEnd = true;
+      break;
+    }
+    numStreams++;
+    firstItem = false;
+    outStreamSpec->InitCRC();
+
+    result = decoder.Code(st, outStream, progress);
+
+    UInt64 member_size = decoder.GetInputProcessedSize() - packSize;
+    packSize += member_size;
+    UInt64 data_size = outStreamSpec->GetSize() - unpackSize;
+    unpackSize += data_size;
+
+    if (result == S_OK)
+    {
+      CTrailer trailer;
+      RINOK(decoder.ReadInput(trailer.data, CTrailer::size, &processed));
+      packSize += processed; member_size += processed;
+      if (processed != CTrailer::size ||
+          trailer.data_crc() != outStreamSpec->GetCRC() ||
+          trailer.data_size() != data_size ||
+          trailer.member_size() != member_size)
+      {
+        crcError = true;
+        result = S_FALSE;
+        break;
+      }
+    }
+    if (result == S_FALSE)
+      break;
+    RINOK(result);
+  }
+
+  if (firstItem)
+  {
+    _isArc = false;
+    result = S_FALSE;
+  }
+  else if (result == S_OK || result == S_FALSE)
+  {
+    if (dataAfterEnd)
+      _dataAfterEnd = true;
+    else if (decoder._lzmaDecoderSpec->NeedsMoreInput())
+      _needMoreInput = true;
+
+    _packSize = packSize;
+    _unpackSize = unpackSize;
+    _numStreams = numStreams;
+
+    _packSize_Defined = true;
+    _unpackSize_Defined = true;
+    _numStreams_Defined = true;
+  }
+
+  Int32 opResult = NExtract::NOperationResult::kOK;
+
+  if (!_isArc)
+    opResult = NExtract::NOperationResult::kIsNotArc;
+  else if (_needMoreInput)
+    opResult = NExtract::NOperationResult::kUnexpectedEnd;
+  else if (crcError)
+    opResult = NExtract::NOperationResult::kCRCError;
+  else if (_dataAfterEnd)
+    opResult = NExtract::NOperationResult::kDataAfterEnd;
+  else if (result == S_FALSE)
+    opResult = NExtract::NOperationResult::kDataError;
+  else if (result == S_OK)
+    opResult = NExtract::NOperationResult::kOK;
+  else
+    return result;
+
+  outStream.Release();
+  return extractCallback->SetOperationResult(opResult);
+
+  COM_TRY_END
+}
+
+REGISTER_ARC_I(
+  "lzip", "lz tlz", "* .tar", 0xC6,
+  k_Signature,
+  0,
+  NArcInfoFlags::kKeepName,
+  IsArc_Lz)
+
+}}

--- a/CPP/7zip/Bundles/Alone/makefile.list
+++ b/CPP/7zip/Bundles/Alone/makefile.list
@@ -73,6 +73,7 @@ SRCS=\
   ../../../../CPP/7zip/Archive/Zip/ZipUpdate.cpp \
   ../../../../CPP/7zip/Archive/ZstdHandler.cpp \
   ../../../../CPP/7zip/Archive/LizardHandler.cpp \
+  ../../../../CPP/7zip/Archive/LzHandler.cpp \
   ../../../../CPP/7zip/Archive/Lz4Handler.cpp \
   ../../../../CPP/7zip/Archive/Lz5Handler.cpp \
   ../../../../CPP/7zip/Common/CWrappers.cpp \
@@ -751,6 +752,10 @@ ZstdHandler.o : ../../../../CPP/7zip/Archive/ZstdHandler.cpp
 LizardHandler.o : ../../../../CPP/7zip/Archive/LizardHandler.cpp 
 	$(CXX) $(CXXFLAGS) ../../../../CPP/7zip/Archive/LizardHandler.cpp
 
+# lzip
+LzHandler.o : ../../../../CPP/7zip/Archive/LzHandler.cpp 
+	$(CXX) $(CXXFLAGS) ../../../../CPP/7zip/Archive/LzHandler.cpp 
+
 # Lz4 ARC
 Lz4Handler.o : ../../../../CPP/7zip/Archive/Lz4Handler.cpp 
 	$(CXX) $(CXXFLAGS) ../../../../CPP/7zip/Archive/Lz4Handler.cpp 
@@ -1339,6 +1344,7 @@ OBJS=\
  Lz4Decoder.o \
  Lz4Encoder.o \
  Lz4Register.o \
+ LzHandler.o \
  Lz4Handler.o \
  Lz5Handler.o \
  XzDecoder.o \

--- a/CPP/7zip/Bundles/Alone7z/makefile.list
+++ b/CPP/7zip/Bundles/Alone7z/makefile.list
@@ -42,6 +42,7 @@ SRCS=\
   ../../../../CPP/7zip/Archive/Common/MultiStream.cpp \
   ../../../../CPP/7zip/Archive/Common/OutStreamWithCRC.cpp \
   ../../../../CPP/7zip/Archive/Common/ParseProperties.cpp \
+  ../../../../CPP/7zip/Archive/LzHandler.cpp \
   ../../../../CPP/7zip/Archive/LzmaHandler.cpp \
   ../../../../CPP/7zip/Archive/SplitHandler.cpp \
   ../../../../CPP/7zip/Archive/XzHandler.cpp \
@@ -309,6 +310,8 @@ OutStreamWithCRC.o : ../../../../CPP/7zip/Archive/Common/OutStreamWithCRC.cpp
 	$(CXX) $(CXXFLAGS) ../../../../CPP/7zip/Archive/Common/OutStreamWithCRC.cpp
 ParseProperties.o : ../../../../CPP/7zip/Archive/Common/ParseProperties.cpp
 	$(CXX) $(CXXFLAGS) ../../../../CPP/7zip/Archive/Common/ParseProperties.cpp
+LzHandler.o : ../../../../CPP/7zip/Archive/LzHandler.cpp 
+	$(CXX) $(CXXFLAGS) ../../../../CPP/7zip/Archive/LzHandler.cpp 
 LzmaHandler.o : ../../../../CPP/7zip/Archive/LzmaHandler.cpp
 	$(CXX) $(CXXFLAGS) ../../../../CPP/7zip/Archive/LzmaHandler.cpp
 SplitHandler.o : ../../../../CPP/7zip/Archive/SplitHandler.cpp
@@ -568,6 +571,7 @@ OBJS=\
  MultiStream.o \
  OutStreamWithCRC.o \
  ParseProperties.o \
+ LzHandler.o \
  LzmaHandler.o \
  SplitHandler.o \
  XzHandler.o \

--- a/CPP/7zip/Bundles/Format7zFree/makefile.list
+++ b/CPP/7zip/Bundles/Format7zFree/makefile.list
@@ -127,6 +127,7 @@ SRCS=\
   ../../../../CPP/7zip/Archive/Zip/ZipUpdate.cpp \
   ../../../../CPP/7zip/Archive/ZstdHandler.cpp \
   ../../../../CPP/7zip/Archive/LizardHandler.cpp \
+  ../../../../CPP/7zip/Archive/LzHandler.cpp \
   ../../../../CPP/7zip/Archive/Lz4Handler.cpp \
   ../../../../CPP/7zip/Archive/Lz5Handler.cpp \
   ../../../../CPP/7zip/Common/CWrappers.cpp \
@@ -910,6 +911,10 @@ ZstdHandler.o : ../../../../CPP/7zip/Archive/ZstdHandler.cpp
 LizardHandler.o : ../../../../CPP/7zip/Archive/LizardHandler.cpp 
 	$(CXX) $(CXXFLAGS) ../../../../CPP/7zip/Archive/LizardHandler.cpp
 
+# lzip
+LzHandler.o : ../../../../CPP/7zip/Archive/LzHandler.cpp 
+	$(CXX) $(CXXFLAGS) ../../../../CPP/7zip/Archive/LzHandler.cpp 
+
 # Lz4 ARC
 Lz4Handler.o : ../../../../CPP/7zip/Archive/Lz4Handler.cpp 
 	$(CXX) $(CXXFLAGS) ../../../../CPP/7zip/Archive/Lz4Handler.cpp 
@@ -1488,6 +1493,7 @@ OBJS=\
  Lz4Decoder.o \
  Lz4Encoder.o \
  Lz4Register.o \
+ LzHandler.o \
  Lz4Handler.o \
  Lz5Handler.o \
  XzDecoder.o \

--- a/CPP/7zip/CMAKE/7za/CMakeLists.txt
+++ b/CPP/7zip/CMAKE/7za/CMakeLists.txt
@@ -201,6 +201,7 @@ add_executable(7za
   "../../../../CPP/7zip/Archive/Zip/ZipRegister.cpp"
   "../../../../CPP/7zip/Archive/Zip/ZipUpdate.cpp"
   "../../../../CPP/7zip/Archive/LizardHandler.cpp"
+  "../../../../CPP/7zip/Archive/LzHandler.cpp"
   "../../../../CPP/7zip/Archive/Lz4Handler.cpp"
   "../../../../CPP/7zip/Archive/Lz5Handler.cpp"
   "../../../../CPP/7zip/Archive/ZstdHandler.cpp"

--- a/CPP/7zip/CMAKE/Format7zFree/CMakeLists.txt
+++ b/CPP/7zip/CMAKE/Format7zFree/CMakeLists.txt
@@ -259,6 +259,7 @@ add_library(7z MODULE
   "../../../../CPP/7zip/Archive/Zip/ZipRegister.cpp"
   "../../../../CPP/7zip/Archive/Zip/ZipUpdate.cpp"
   "../../../../CPP/7zip/Archive/LizardHandler.cpp"
+  "../../../../CPP/7zip/Archive/LzHandler.cpp"
   "../../../../CPP/7zip/Archive/Lz4Handler.cpp"
   "../../../../CPP/7zip/Archive/Lz5Handler.cpp"
   "../../../../CPP/7zip/Archive/ZstdHandler.cpp"

--- a/CPP/7zip/Guid.txt
+++ b/CPP/7zip/Guid.txt
@@ -163,6 +163,7 @@ Handler GUIDs:
   0C xz
   0D ppmd
 
+  C6 Lzip
   C7 Ext
   C8 VMDK
   C9 VDI

--- a/CPP/7zip/PREMAKE/premake4.lua
+++ b/CPP/7zip/PREMAKE/premake4.lua
@@ -212,6 +212,7 @@ solution "p7zip"
       "../../../../CPP/7zip/Archive/Zip/ZipRegister.cpp",
       "../../../../CPP/7zip/Archive/Zip/ZipUpdate.cpp",
       "../../../../CPP/7zip/Archive/LizardHandler.cpp",
+      "../../../../CPP/7zip/Archive/LzHandler.cpp",
       "../../../../CPP/7zip/Archive/Lz4Handler.cpp",
       "../../../../CPP/7zip/Archive/Lz5Handler.cpp",
       "../../../../CPP/7zip/Archive/ZstdHandler.cpp",

--- a/CPP/7zip/QMAKE/7za/7za.pro
+++ b/CPP/7zip/QMAKE/7za/7za.pro
@@ -215,6 +215,7 @@ SOURCES +=  \
   ../../../../CPP/7zip/Archive/Zip/ZipRegister.cpp \
   ../../../../CPP/7zip/Archive/Zip/ZipUpdate.cpp \
   ../../../../CPP/7zip/Archive/LizardHandler.cpp \
+  ../../../../CPP/7zip/Archive/LzHandler.cpp \
   ../../../../CPP/7zip/Archive/Lz4Handler.cpp \
   ../../../../CPP/7zip/Archive/Lz5Handler.cpp \
   ../../../../CPP/7zip/Archive/ZstdHandler.cpp \

--- a/CPP/7zip/QMAKE/Format7zFree/Format7zFree.pro
+++ b/CPP/7zip/QMAKE/Format7zFree/Format7zFree.pro
@@ -273,6 +273,7 @@ SOURCES +=  \
   ../../../../CPP/7zip/Archive/Zip/ZipRegister.cpp \
   ../../../../CPP/7zip/Archive/Zip/ZipUpdate.cpp \
   ../../../../CPP/7zip/Archive/LizardHandler.cpp \
+  ../../../../CPP/7zip/Archive/LzHandler.cpp \
   ../../../../CPP/7zip/Archive/Lz4Handler.cpp \
   ../../../../CPP/7zip/Archive/Lz5Handler.cpp \
   ../../../../CPP/7zip/Archive/ZstdHandler.cpp \

--- a/CPP/7zip/UI/Common/OpenArchive.cpp
+++ b/CPP/7zip/UI/Common/OpenArchive.cpp
@@ -1066,6 +1066,7 @@ static const char * const k_Formats_with_simple_signuature[] =
   , "rar"
   , "bzip2"
   , "gzip"
+  , "lzip"
   , "cab"
   , "wim"
   , "rpm"

--- a/CPP/7zip/UI/GUI/CompressDialog.h
+++ b/CPP/7zip/UI/GUI/CompressDialog.h
@@ -183,7 +183,7 @@ public:
   CUIntVector ArcIndices; // can not be empty, must contain Info.FormatIndex, if Info.FormatIndex >= 0
 
   NCompressDialog::CInfo Info;
-  UString OriginalFileName; // for bzip2, gzip2
+  UString OriginalFileName; // for bzip2, gzip2, lzip
   bool CurrentDirWasChanged;
 
   INT_PTR Create(HWND wndParent = 0)

--- a/CPP/ANDROID/7za/jni/Android.mk
+++ b/CPP/ANDROID/7za/jni/Android.mk
@@ -90,6 +90,7 @@ LOCAL_SRC_FILES := \
   ../../../../CPP/7zip/Archive/Zip/ZipRegister.cpp \
   ../../../../CPP/7zip/Archive/Zip/ZipUpdate.cpp \
   ../../../../CPP/7zip/Archive/LizardHandler.cpp \
+  ../../../../CPP/7zip/Archive/LzHandler.cpp \
   ../../../../CPP/7zip/Archive/Lz4Handler.cpp \
   ../../../../CPP/7zip/Archive/Lz5Handler.cpp \
   ../../../../CPP/7zip/Archive/ZstdHandler.cpp \

--- a/CPP/ANDROID/Format7zFree/jni/Android.mk
+++ b/CPP/ANDROID/Format7zFree/jni/Android.mk
@@ -126,6 +126,7 @@ LOCAL_SRC_FILES := \
   ../../../../CPP/7zip/Archive/Zip/ZipRegister.cpp \
   ../../../../CPP/7zip/Archive/Zip/ZipUpdate.cpp \
   ../../../../CPP/7zip/Archive/LizardHandler.cpp \
+  ../../../../CPP/7zip/Archive/LzHandler.cpp \
   ../../../../CPP/7zip/Archive/Lz4Handler.cpp \
   ../../../../CPP/7zip/Archive/Lz5Handler.cpp \
   ../../../../CPP/7zip/Archive/ZstdHandler.cpp \

--- a/DOC/MANUAL/cmdline/index.htm
+++ b/DOC/MANUAL/cmdline/index.htm
@@ -15,7 +15,7 @@
 from the 7-Zip package. 7z.dll is used by the 7-Zip File Manager also.</LI>
 
 <P>7za.exe (a = alone) is a standalone version of 7-Zip.
-7za.exe supports only 7z, lzma, cab, zip, gzip, bzip2, Z and tar formats.
+7za.exe supports only 7z, lzma, cab, zip, gzip, bzip2, lzip, Z and tar formats.
 7za.exe doesn't use external modules.</LI>
 
 <UL>

--- a/DOC/MANUAL/cmdline/switches/stdin.htm
+++ b/DOC/MANUAL/cmdline/switches/stdin.htm
@@ -24,7 +24,7 @@
     If file_name is not specified, data will be stored without a name.</DD>
 </DL>
 
-<P>Note: The current version of 7-Zip support reading of archives from stdin only for xz, lzma, tar, gzip and bzip2 archives.</P>
+<P>Note: The current version of 7-Zip supports reading of archives from stdin only for xz, lzma, tar, gzip, bzip2 and lzip archives.</P>
 
 <H4>Examples</H4>
 

--- a/DOC/MANUAL/cmdline/switches/stx.htm
+++ b/DOC/MANUAL/cmdline/switches/stx.htm
@@ -22,7 +22,7 @@
 
 <DL>
   <DT>{archive_type}</DT>
-    <DD> Specifies the type of archive. It can be: 7z, xz, split, zip, gzip, bzip2, tar, ....
+    <DD> Specifies the type of archive. It can be: 7z, xz, split, zip, gzip, bzip2, lzip, tar, ....
     </DD>
 </DL>
 

--- a/DOC/MANUAL/cmdline/switches/type.htm
+++ b/DOC/MANUAL/cmdline/switches/type.htm
@@ -20,7 +20,7 @@
 
 <DL>
   <DT>{archive_type}</DT>
-    <DD> Specifies the type of archive. It can be: *, #, 7z, xz, split, zip, gzip, bzip2, tar, ....
+    <DD> Specifies the type of archive. It can be: *, #, 7z, xz, split, zip, gzip, bzip2, lzip, tar, ....
     </DD>
 
   <DT>*:r</DT>
@@ -65,7 +65,7 @@ archive without compression (for example, MBR in VHD), 7-Zip can open both
 levels in one step. If you want to open/extract just top 
 level archive, use <SPAN class="filename">-t*</SPAN> switch.</P>
 
-<P>Note: xz, gzip and bzip2 formats support only one file per archive.
+<P>Note: xz, gzip, bzip2 and lzip formats support only one file per archive.
 If you want to compress more than one file to these formats,
 create a tar archive at first, and then compress it with your selected format.</P>
 

--- a/DOC/MANUAL/general/formats.htm
+++ b/DOC/MANUAL/general/formats.htm
@@ -40,6 +40,7 @@
   <TR> <TD align="center">iHEX</TD> <TD></TD> <TD>ihex</TD> </TR>
   <TR> <TD align="center">ISO</TD> <TD></TD> <TD>iso img</TD> </TR>
   <TR> <TD align="center"><A href="#lzh">LZH</A></TD> <TD></TD> <TD>lzh lha</TD></TR>
+  <TR> <TD align="center">LZIP</TD> <TD></TD> <TD>lz tlz</TD> </TR>
   <TR> <TD align="center">LZMA</TD> <TD></TD> <TD>lzma</TD> </TR>
   <TR> <TD align="center">MBR</TD> <TD></TD> <TD>mbr</TD> </TR>
   <TR> <TD align="center">MsLZ</TD> <TD></TD> <TD>mslz</TD> </TR>

--- a/DOC/readme.txt
+++ b/DOC/readme.txt
@@ -123,7 +123,7 @@ Windows           common files for Windows related code
 
   Bundle          Modules that are bundles of other modules (files)
 
-    Alone         7za.exe: Standalone version of 7-Zip console that supports only 7z/xz/cab/zip/gzip/bzip2/tar.
+    Alone         7za.exe: Standalone version of 7-Zip console that supports only 7z/xz/cab/zip/gzip/bzip2/lzip/tar.
     Alone7z       7zr.exe: Standalone version of 7-Zip console that supports only 7z (reduced version)
     Fm            Standalone version of 7-Zip File Manager
     Format7z            7za.dll:  .7z support

--- a/GUI/Contents/Info.plist
+++ b/GUI/Contents/Info.plist
@@ -142,6 +142,44 @@
 		<dict>
 			<key>CFBundleTypeExtensions</key>
 			<array>
+				<string>lz</string>
+				<string>LZ</string>
+				<string>lzip</string>
+				<string>LZIP</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>/System/Library/CoreServices/Archive Utility.app/Contents/Resources/bah-lz.icns</string>
+			<key>CFBundleTypeName</key>
+			<string>LZip</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+			<key>NSPersistentStoreTypeKey</key>
+			<string>XML</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>tlz</string>
+				<string>TLZ</string>
+				<string>tlzip</string>
+				<string>TLZIP</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>/System/Library/CoreServices/Archive Utility.app/Contents/Resources/bah-tlz.icns</string>
+			<key>CFBundleTypeName</key>
+			<string>TLZip</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+			<key>NSPersistentStoreTypeKey</key>
+			<string>XML</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
 				<string>tar</string>
 				<string>TAR</string>
 			</array>

--- a/GUI/kde3/p7zip_extract.desktop
+++ b/GUI/kde3/p7zip_extract.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 X-SuSE-translate=true
 Encoding=UTF-8
-ServiceTypes=application/x-gzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
+ServiceTypes=application/x-gzip,application/x-lzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tlz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
 Actions=extractHere
 
 [Desktop Action extractHere]

--- a/GUI/kde3/p7zip_extract_subdir.desktop
+++ b/GUI/kde3/p7zip_extract_subdir.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 X-SuSE-translate=true
 Encoding=UTF-8
-ServiceTypes=application/x-gzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
+ServiceTypes=application/x-gzip,application/x-lzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tlz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
 Actions=ExtractSubdir
 
 [Desktop Action ExtractSubdir]

--- a/GUI/kde3/p7zip_extract_to.desktop
+++ b/GUI/kde3/p7zip_extract_to.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 X-SuSE-translate=true
 Encoding=UTF-8
-ServiceTypes=application/x-gzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
+ServiceTypes=application/x-gzip,application/x-lzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tlz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
 Actions=ExtractTo
 
 [Desktop Action ExtractTo]

--- a/GUI/kde3/p7zip_test.desktop
+++ b/GUI/kde3/p7zip_test.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 X-SuSE-translate=true
 Encoding=UTF-8
-ServiceTypes=application/x-gzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
+ServiceTypes=application/x-gzip,application/x-lzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tlz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
 Actions=test
 
 [Desktop Action test]

--- a/GUI/kde4/p7zip_extract.desktop
+++ b/GUI/kde4/p7zip_extract.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-ServiceTypes=application/x-gzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
+ServiceTypes=application/x-gzip,application/x-lzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tlz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
 Actions=extractHere;
 Type=Service
 X-KDE-ServiceTypes=KonqPopupMenu/Plugin

--- a/GUI/kde4/p7zip_extract_subdir.desktop
+++ b/GUI/kde4/p7zip_extract_subdir.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-ServiceTypes=application/x-gzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
+ServiceTypes=application/x-gzip,application/x-lzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tlz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
 Actions=ExtractSubdir;
 Type=Service
 X-KDE-ServiceTypes=KonqPopupMenu/Plugin

--- a/GUI/kde4/p7zip_extract_to.desktop
+++ b/GUI/kde4/p7zip_extract_to.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-ServiceTypes=application/x-gzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
+ServiceTypes=application/x-gzip,application/x-lzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tlz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
 Actions=ExtractTo;
 Type=Service
 X-KDE-ServiceTypes=KonqPopupMenu/Plugin

--- a/GUI/kde4/p7zip_test.desktop
+++ b/GUI/kde4/p7zip_test.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-ServiceTypes=application/x-gzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
+ServiceTypes=application/x-gzip,application/x-lzip,application/x-lha,application/x-tar,application/x-tgz,application/x-tlz,application/x-tbz,application/x-tbz2,application/x-zip,application/x-bzip,application/x-tzo,application/x-lzop,application/x-rar,application/x-rar-compressed,application/x-zoo,application/x-tarz,application/x-archive,application/x-bzip2,application/x-jar,application/x-deb,application/x-ace,application/x-7z,application/x-arc,application/x-arj,application/x-compress,application/x-cpio,application/x-pak
 Actions=test;
 Type=Service
 X-KDE-ServiceTypes=KonqPopupMenu/Plugin

--- a/Utils/file_7z_so.py
+++ b/Utils/file_7z_so.py
@@ -244,6 +244,7 @@ files_cpp=[
  'CPP/7zip/Archive/Zip/ZipRegister.cpp',
  'CPP/7zip/Archive/Zip/ZipUpdate.cpp',
  'CPP/7zip/Archive/LizardHandler.cpp',
+ 'CPP/7zip/Archive/LzHandler.cpp',
  'CPP/7zip/Archive/Lz4Handler.cpp',
  'CPP/7zip/Archive/Lz5Handler.cpp',
  'CPP/7zip/Archive/ZstdHandler.cpp',

--- a/Utils/file_7za.py
+++ b/Utils/file_7za.py
@@ -186,6 +186,7 @@ files_cpp=[
  'CPP/7zip/Archive/Zip/ZipRegister.cpp',
  'CPP/7zip/Archive/Zip/ZipUpdate.cpp',
  'CPP/7zip/Archive/LizardHandler.cpp',
+ 'CPP/7zip/Archive/LzHandler.cpp',
  'CPP/7zip/Archive/Lz4Handler.cpp',
  'CPP/7zip/Archive/Lz5Handler.cpp',
  'CPP/7zip/Archive/ZstdHandler.cpp',

--- a/man1/7z.1
+++ b/man1/7z.1
@@ -82,7 +82,7 @@ Write data to StdOut (eg: % echo foo | 7z a dummy \-tgzip \-si \-so > /dev/null)
 Sets technical mode for l (list) command
 .TP
 .B \-t{Type}
-Type of archive (7z, zip, gzip, bzip2 or tar. 7z format is default)
+Type of archive (7z, zip, gzip, bzip2, lzip or tar. 7z format is default)
 .TP
 .B \-v{Size}[b|k|m|g]
 Create volumes
@@ -165,7 +165,7 @@ add all files from directory "dir1" to SFX archive archive.exe (Remark : SFX arc
 7z a \-mhe=on \-pmy_password archive.7z a_directory
 add all files from directory "a_directory" to the archive "archive.7z" (with data and header archive encryption on)
 .SH "SEE ALSO"
-7za(1), 7zr(1), bzip2(1), gzip(1), zip(1)
+7za(1), 7zr(1), bzip2(1), gzip(1), lzip(1), zip(1)
 .PP
 .SH "HTML Documentation"
 {DEST_SHARE_DOC}/MANUAL/index.htm

--- a/man1/7za.1
+++ b/man1/7za.1
@@ -82,7 +82,7 @@ Write data to StdOut (eg: % echo foo | 7z a dummy \-tgzip \-si \-so > /dev/null)
 Sets technical mode for l (list) command
 .TP
 .B \-t{Type}
-Type of archive (7z, zip, gzip, bzip2 or tar. 7z format is default)
+Type of archive (7z, zip, gzip, bzip2, lzip or tar. 7z format is default)
 .TP
 .B \-v{Size}[b|k|m|g]
 Create volumes
@@ -165,7 +165,7 @@ add all files from directory "dir1" to SFX archive archive.exe (Remark : SFX arc
 7za a \-mhe=on \-pmy_password archive.7z a_directory
 add all files from directory "a_directory" to the archive "archive.7z" (with data and header archive encryption on)
 .SH "SEE ALSO"
-7z(1), 7zr(1), bzip2(1), gzip(1), zip(1)
+7z(1), 7zr(1), bzip2(1), gzip(1), lzip(1), zip(1)
 .PP
 .SH "HTML Documentation"
 {DEST_SHARE_DOC}/MANUAL/index.htm


### PR DESCRIPTION
The patch was written for (p)7zip-1604 by the lzip author
It was slightly modified to make it apply to this version..

lzip is included in:
- 7z
- 7za

Source: https://download.savannah.gnu.org/releases/lzip/7zip/
https://download.savannah.gnu.org/releases/lzip/p7zip_16.02_lzip-1.tar.bz2

I performed some tests and it seems to work fine..