### PR TITLE
check.sh: (zstd): use -mx=20 instead of -mx=22

### DIFF
--- a/check/check.sh
+++ b/check/check.sh
@@ -116,7 +116,7 @@ sure ${P7ZIP} a -t7z 7za433_7zip_BCJ2.7z 7za433_7zip_lzma -m0=BCJ2
 
 sure ${P7ZIP} a -t7z 7za433_7zip_Copy.7z 7za433_7zip_lzma -m0=Copy
 
-sure ${P7ZIP} a -t7z 7za433_7zip_zstd.7z 7za433_7zip_lzma -m0=zstd -mx=22 # mx=level
+sure ${P7ZIP} a -t7z 7za433_7zip_zstd.7z 7za433_7zip_lzma -m0=zstd -mx=20 # mx=level
 
 sure ${P7ZIP} a -t7z 7za433_7zip_lz4.7z 7za433_7zip_lzma -m0=lz4 -mmt=on # mmt=multithreading mode
 
@@ -138,7 +138,7 @@ sure ${P7ZIP} a -t7z 7za433_7zip_lzma6.7z 7za433_7zip_lzma -m0=LZMA -mf=BCJ2 -mt
 
 sure ${P7ZIP} a -t7z 7za433_7zip_lzma7.7z 7za433_7zip_lzma -m0=LZMA -mf=SPARC -mta=on # mta=last Access timestamps
 
-sure ${P7ZIP} a -t7z 7za433_7zip.7z 7za433_7zip_lzma -m0=bcj -m1=zstd -mx=22
+sure ${P7ZIP} a -t7z 7za433_7zip.7z 7za433_7zip_lzma -m0=bcj -m1=zstd -mx=20
 
 sure ${P7ZIP} a -tzip 7za433_7zip_lzma.zip 7za433_7zip_lzma
 

--- a/check/check_7za.sh
+++ b/check/check_7za.sh
@@ -85,7 +85,7 @@ sure ${P7ZIP} a -mx=9 -m0=ppmd:mem=64m:o=32 7za433_7zip_ppmd.7z 7za433_7zip_ppmd
 
 sure ${P7ZIP} a -m0=bzip2 7za433_7zip_bzip2.7z 7za433_7zip_bzip2
 
-sure ${P7ZIP} a -t7z 7za433_7zip_zstd.7z 7za433_7zip_lzma -m0=zstd -mx=22 # mx=level
+sure ${P7ZIP} a -t7z 7za433_7zip_zstd.7z 7za433_7zip_lzma -m0=zstd -mx=20 # mx=level
 
 sure ${P7ZIP} a -m0=lz4 7za433_7zip_lz4.7z 7za433_7zip_lzma
 


### PR DESCRIPTION
apparently -mx=22 requires an insane amount of RAM

the test files are < 500kb but the test apparently requires more than 2GB of RAM
that certainly make the test fail even when there is plenty of ram

-mx=20 requires far less ram, even =21 seems ok, but =22 is i.n.s.a.n.e

but this needs to be tested on a Raspberry Pi 3 (1GB ram)