### PR TITLE
add "exec" to wrapper script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ installShared()
     chmod 755 "${DEST_DIR}${DEST_SHARE}/${prg}"
     strip     "${DEST_DIR}${DEST_SHARE}/${prg}"
     echo "#! /bin/sh" > "${DEST_DIR}${DEST_BIN}/${prg}"
-    echo "\"${DEST_SHARE}/${prg}\" \"\$@\"" >> "${DEST_DIR}${DEST_BIN}/${prg}"
+    echo "exec \"${DEST_SHARE}/${prg}\" \"\$@\"" >> "${DEST_DIR}${DEST_BIN}/${prg}"
     chmod 755 "${DEST_DIR}${DEST_BIN}/${prg}"
   fi
 }


### PR DESCRIPTION
Some ways of invoking `7z` involve specifying a password on the command line. To provide some amount of protection in this situation, p7zip will hide the command line parameters you can see with `ps` or `top`. Unfortunately, this wrapper script has no such protection, so the password is still visible. Adding `exec` solves that.

![image](https://user-images.githubusercontent.com/2379774/113889171-f7002a00-9790-11eb-806a-6dab6ac6c1bf.png)