### PR TITLE
Reproducible Builds: Do no embed timestamps in man pages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -159,9 +159,9 @@ else
    chmod 644 "${DEST_DIR}${DEST_MAN}/man1/7zr.1"
 fi
 
-gzip "${DEST_DIR}${DEST_MAN}/man1/7z.1"
-gzip "${DEST_DIR}${DEST_MAN}/man1/7za.1"
-gzip "${DEST_DIR}${DEST_MAN}/man1/7zr.1"
+gzip -n "${DEST_DIR}${DEST_MAN}/man1/7z.1"
+gzip -n "${DEST_DIR}${DEST_MAN}/man1/7za.1"
+gzip -n "${DEST_DIR}${DEST_MAN}/man1/7zr.1"
 
 if [ -f README ]
 then


### PR DESCRIPTION
This was discovered by the [Arch Linux Reproducible Builds](https://reproducible.archlinux.org/) infrastructure:
```
aba3d
│ ├── usr/share/man/man1/7z.1.gz
│ │ ├── filetype from file(1)
│ │ │ @@ -1 +1 @@
│ │ │ -gzip compressed data, was "7z.1", last modified: Sun Apr  4 05:18:33 2021, from Unix
│ │ │ +gzip compressed data, was "7z.1", last modified: Sun May 16 03:29:14 2021, from Unix
│ ├── usr/share/man/man1/7za.1.gz
│ │ ├── filetype from file(1)
│ │ │ @@ -1 +1 @@
│ │ │ -gzip compressed data, was "7za.1", last modified: Sun Apr  4 05:18:33 2021, from Unix
│ │ │ +gzip compressed data, was "7za.1", last modified: Sun May 16 03:29:14 2021, from Unix
│ ├── usr/share/man/man1/7zr.1.gz
│ │ ├── filetype from file(1)
│ │ │ @@ -1 +1 @@
│ │ │ -gzip compressed data, was "7zr.1", last modified: Sun Apr  4 05:18:33 2021, from Unix
│ │ │ +gzip compressed data, was "7zr.1", last modified: Sun May 16 03:29:14 2021, from Unix
```