### PR TITLE
docs(man): fix path to HTML help pages

### DIFF
--- a/man1/7z.1
+++ b/man1/7z.1
@@ -168,7 +168,7 @@ add all files from directory "a_directory" to the archive "archive.7z" (with dat
 7za(1), 7zr(1), bzip2(1), gzip(1), lzip(1), zip(1)
 .PP
 .SH "HTML Documentation"
-{DEST_SHARE_DOC}/MANUAL/index.htm
+{DEST_SHARE_DOC}/MANUAL/start.htm
 .SH AUTHOR
 .TP
 Written for Debian by Mohammed Adnene Trojette.

--- a/man1/7za.1
+++ b/man1/7za.1
@@ -168,7 +168,7 @@ add all files from directory "a_directory" to the archive "archive.7z" (with dat
 7z(1), 7zr(1), bzip2(1), gzip(1), lzip(1), zip(1)
 .PP
 .SH "HTML Documentation"
-{DEST_SHARE_DOC}/MANUAL/index.htm
+{DEST_SHARE_DOC}/MANUAL/start.htm
 .SH AUTHOR
 .TP
 Written for Debian by Mohammed Adnene Trojette.

--- a/man1/7zr.1
+++ b/man1/7zr.1
@@ -165,7 +165,7 @@ add all files from directory "a_directory" to the archive "archive.7z" (with dat
 7z(1), 7za(1), bzip2(1), gzip(1), zip(1)
 .PP
 .SH "HTML Documentation"
-{DEST_SHARE_DOC}/MANUAL/index.htm
+{DEST_SHARE_DOC}/MANUAL/start.htm
 .SH AUTHOR
 .TP
 Written for Debian by Mohammed Adnene Trojette.


### PR DESCRIPTION
The path ends with `index.htm` but should be `start.htm`.
![image](https://user-images.githubusercontent.com/1161280/137191973-94cfd42f-8ae6-422a-beb3-54bb7974f7f9.png)
