### PR TITLE
Fix CLI password entry for illumos

### DIFF
--- a/CPP/7zip/Archive/Zip/ZipItem.cpp
+++ b/CPP/7zip/Archive/Zip/ZipItem.cpp
@@ -5,6 +5,10 @@
 #include <locale.h>
 #endif
 
+#if (defined __illumos__)
+#include <strings.h>    // for bzero
+#endif
+
 #include "StdAfx.h"
 
 #include "../../../../C/CpuArch.h"

--- a/CPP/7zip/UI/Console/UserInputUtils.cpp
+++ b/CPP/7zip/UI/Console/UserInputUtils.cpp
@@ -89,12 +89,20 @@ UString GetPassword(CStdOutStream *outStream,bool verify)
     outStream->Flush();
   }
 #ifdef ENV_HAVE_GETPASS
+#if defined(__illumos__)
+  AString oemPassword = getpassphrase("");
+#else
   AString oemPassword = getpass("");
+#endif
   if ( (verify) && (outStream) )
   {
     (*outStream) << "Verify password (will not be echoed) :";
     outStream->Flush();
+#if defined(__illumos__)
+    AString oemPassword2 = getpassphrase("");
+#else
     AString oemPassword2 = getpass("");
+#endif
     if (oemPassword != oemPassword2) throw "password verification failed";
   }
   return MultiByteToUnicodeString(oemPassword, CP_OEMCP);


### PR DESCRIPTION
It was pointed out to me that to have a look at this repo as the sourceforge repo seems abandoned.
Hoping to spread the love with this fix to other forkers.

Basically, because Solaris nerfed getpass(), getpassphrase() should be called instead on Illumos.

This is rather insidious as it "self-consistent" - one thinks one is making encrypted archives with long passwords which can't be opened on eg Linux, or vice-versa, but which can be expanded only the system on which they were made. ..until one realizes one can open them on Linux by typing only 8 characters, but on Illumos, one must currently use the command-line-passed password form.

Because this repo seems not to support GUI, this is extra-important.

Reported to:
- https://sourceforge.net/p/p7zip/bugs/230/ 
- https://github.com/omniosorg/omnios-build/issues/2457
- https://github.com/joyent/pkgsrc/issues/312

- Also simple fix for a missing define