### PR TITLE
correct duplicated 'for' in `-scc' switch help

### DIFF
--- a/CPP/7zip/UI/Console/Main.cpp
+++ b/CPP/7zip/UI/Console/Main.cpp
@@ -137,7 +137,7 @@ static const char * const kHelpString =
     #endif
     "  -r[-|0] : Recurse subdirectories\n"
     "  -sa{a|e|s} : set Archive name mode\n"
-    "  -scc{UTF-8|WIN|DOS} : set charset for for console input/output\n"
+    "  -scc{UTF-8|WIN|DOS} : set charset for console input/output\n"
     "  -scs{UTF-8|UTF-16LE|UTF-16BE|WIN|DOS|{id}} : set charset for list files\n"
     "  -scrc[CRC32|CRC64|SHA1|SHA256|*] : set hash function for x, e, h commands\n"
     "  -sdel : delete files after compression\n"


### PR DESCRIPTION
There is duplicated for in help for \`-scc' switch.

I would add it to 22.00 branch as well but don't know how to do that - `git clone` cloned only master branch; there are no other branches.
 